### PR TITLE
Use absolute path for log to fix broken image in some contexts

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -11,7 +11,7 @@
         <br />
         <a href="https://lists.cs.columbia.edu/mailman/listinfo/cucyber">Join our mailing list!</a>
         <br />
-        <img src="small_cucyber_logo.png"/>
+        <img src="https://github.com/CUCTF/.github/raw/main/profile/small_cucyber_logo.png"/>
         <br />
         <a href="http://cucyber.cs.columbia.edu/">Website</a>
         •


### PR DESCRIPTION
If you view the README.md from this path: https://github.com/CUCTF, the logo does not load correctly. 

This PR should fix that by providing the full raw url. 